### PR TITLE
111 http tidy

### DIFF
--- a/rotala-http/src/bin/uist_server_v2.rs
+++ b/rotala-http/src/bin/uist_server_v2.rs
@@ -25,8 +25,6 @@ async fn main() -> std::io::Result<()> {
             .app_data(uist_state.clone())
             .service(info)
             .service(init)
-            .service(fetch_quotes)
-            .service(fetch_depth)
             .service(tick)
             .service(insert_order)
             .service(modify_order)

--- a/rotala-python/src/broker.py
+++ b/rotala-python/src/broker.py
@@ -162,10 +162,8 @@ class Broker:
         # Initializes backtest_id, can ignore result
         init_response = self.http.init(self.dataset_name)
         self.backtest_id = init_response["backtest_id"]
-        quotes_resp = self.http.fetch_quotes()
-        depth_resp = self.http.fetch_depth()
-        self.latest_quotes = quotes_resp["quotes"]
-        self.latest_depth = depth_resp["quotes"]
+        self.latest_quotes = init_response["bbo"]
+        self.latest_depth = init_response["depth"]
         self.ts = list(self.latest_quotes.values())[0]["date"]
 
     def _update_holdings(self, position: str, chg: float):
@@ -269,10 +267,10 @@ class Broker:
             logger.critical("Sim finished")
             exit(0)
         else:
-            self.latest_quotes = self.http.fetch_quotes()["quotes"]
+            self.latest_quotes = tick_response["bbo"]
+            self.latest_depth = tick_response["depth"]
             if self.latest_quotes:
                 self.ts = list(self.latest_quotes.values())[0]["date"]
-            self.latest_depth = self.http.fetch_depth()["quotes"]
 
         curr_value = self.get_current_value()
         logger.info(f"{self.backtest_id}-{self.ts} TOTAL VALUE: {curr_value}")

--- a/rotala-python/src/http.py
+++ b/rotala-python/src/http.py
@@ -56,20 +56,6 @@ class HttpClient:
         )
         return r.json()
 
-    def fetch_quotes(self):
-        if self.backtest_id is None:
-            raise ValueError("Called before init")
-
-        r = requests.get(f"{self.base_url}/backtest/{self.backtest_id}/fetch_quotes")
-        return r.json()
-
-    def fetch_depth(self):
-        if self.backtest_id is None:
-            raise ValueError("Called before init")
-
-        r = requests.get(f"{self.base_url}/backtest/{self.backtest_id}/fetch_depth")
-        return r.json()
-
     def info(self):
         if self.backtest_id is None:
             raise ValueError("Called before init")


### PR DESCRIPTION
[Root issue](https://github.com/calumrussell/rotala/issues/111)

* Removes fetch_quotes/fetch_depth routes from http
* Moves fetch bbo/depth logic into lifecycle methods, moves data into those responses
* Fixes Rust and Python clients for these changes