### PR TITLE
111 insert groups orders

### DIFF
--- a/rotala-client/src/client/uist_v2.rs
+++ b/rotala-client/src/client/uist_v2.rs
@@ -25,11 +25,11 @@ impl Client for HttpClient {
             .await?)
     }
 
-    async fn insert_order(&mut self, order: Order, backtest_id: BacktestId) -> Result<()> {
-        let req = InsertOrderRequest { order };
+    async fn insert_orders(&mut self, orders: Vec<Order>, backtest_id: BacktestId) -> Result<()> {
+        let req = InsertOrderRequest { orders };
         Ok(self
             .client
-            .post(self.path.clone() + format!("/backtest/{backtest_id}/insert_order").as_str())
+            .post(self.path.clone() + format!("/backtest/{backtest_id}/insert_orders").as_str())
             .json(&req)
             .send()
             .await?
@@ -108,12 +108,13 @@ impl Client for TestClient {
         }
     }
 
-    fn insert_order(
+    fn insert_orders(
         &mut self,
-        order: Order,
+        orders: Vec<Order>,
         backtest_id: BacktestId,
     ) -> impl Future<Output = Result<()>> {
-        if let Some(()) = self.state.insert_order(order, backtest_id) {
+        //TODO: this clone is horrible
+        if let Some(()) = self.state.insert_orders(&mut orders.clone(), backtest_id) {
             future::ready(Ok(()))
         } else {
             future::ready(Err(Error::new(UistV2Error::UnknownBacktest)))

--- a/rotala-http/src/bin/uist_server_v2.rs
+++ b/rotala-http/src/bin/uist_server_v2.rs
@@ -26,7 +26,7 @@ async fn main() -> std::io::Result<()> {
             .service(info)
             .service(init)
             .service(tick)
-            .service(insert_order)
+            .service(insert_orders)
     })
     .bind((address, port))?
     .run()

--- a/rotala-python/main.py
+++ b/rotala-python/main.py
@@ -30,7 +30,8 @@ def risk_management(unexecuted_orders, total_value):
     gross_value = 0
     for order_id in unexecuted_orders:
         order = unexecuted_orders[order_id]
-        gross_value += order.qty * order.price
+        if order.price:
+            gross_value += order.qty * order.price
 
     if gross_value > total_value * 0.1:
         return False
@@ -76,7 +77,11 @@ if __name__ == "__main__":
                 # In practice, we want to look for overlapping levels so we don't need
                 # to clear whole book
                 for order_id in brkr.unexecuted_orders:
-                    brkr.cancel_order(order_id)
+                    order = brkr.unexecuted_orders[order_id]
+                    if order.is_transaction():
+                        brkr.insert_order(
+                            Order(OrderType.Cancel, "SOL", 0, None, order_id)
+                        )
 
                 [
                     brkr.insert_order(order)

--- a/rotala-python/src/http.py
+++ b/rotala-python/src/http.py
@@ -20,13 +20,14 @@ class HttpClient:
         r = requests.get(f"{self.base_url}/backtest/{self.backtest_id}/tick")
         return r.json()
 
-    def insert_order(self, order):
+    def insert_orders(self, orders):
         if self.backtest_id is None:
             raise ValueError("Called before init")
 
-        val = f'{{"order": {order.serialize()}}}'
+        serialized_orders_str = ",".join([o.serialize() for o in orders])
+        val = f'{{"orders": [{serialized_orders_str}]}}'
         r = requests.post(
-            f"{self.base_url}/backtest/{self.backtest_id}/insert_order",
+            f"{self.base_url}/backtest/{self.backtest_id}/insert_orders",
             data=val,
             headers={"Content-type": "application/json"},
         )

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -341,19 +341,19 @@ impl OrderBook {
         orderbook: &mut BTreeMap<OrderId, InnerOrder>,
     ) -> Vec<OrderResult> {
         let mut res = Vec::new();
-        if orderbook
-            .remove(&order_to_cancel.order_id_ref.unwrap())
-            .is_some()
-        {
-            let order_result = OrderResult {
-                symbol: order_to_cancel.symbol.clone(),
-                value: 0.0,
-                quantity: 0.0,
-                date: now,
-                typ: OrderResultType::Cancel,
-                order_id: order_to_cancel.order_id,
-            };
-            res.push(order_result);
+        //Fails silently if you send garbage in
+        if let Some(order_id) = &order_to_cancel.order_id_ref {
+            if orderbook.remove(order_id).is_some() {
+                let order_result = OrderResult {
+                    symbol: order_to_cancel.symbol.clone(),
+                    value: 0.0,
+                    quantity: 0.0,
+                    date: now,
+                    typ: OrderResultType::Cancel,
+                    order_id: order_to_cancel.order_id,
+                };
+                res.push(order_result);
+            }
         }
 
         res

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -159,6 +159,10 @@ impl UistV2 {
         self.order_buffer.push(order);
     }
 
+    pub fn insert_orders(&mut self, orders: &mut Vec<Order>) {
+        self.order_buffer.append(orders);
+    }
+
     pub fn tick(&mut self, quotes: &DateDepth, now: i64) -> (Vec<OrderResult>, Vec<InnerOrder>) {
         //To eliminate lookahead bias, we only insert new orders after we have executed any orders
         //that were on the stack first


### PR DESCRIPTION
[Root issue](https://github.com/calumrussell/rotala/issues/111)

* UistV2 trait now uses `insert_orders` at all times to add 1..N orders
* Implementation for HTTP
* Implementation for Rust client
* Implementation for Python client
* Fix bug that would led to poisoned Mutex if malformed cancel order was sent