### PR TITLE
111 removing mutex from http

### DIFF
--- a/rotala-http/Cargo.toml
+++ b/rotala-http/Cargo.toml
@@ -23,6 +23,8 @@ tokio = { version = "1.35.1", features = ["full"] }
 derive_more = { version = "1.0.0", features = ["full"] }
 anyhow = "1.0.86"
 rotala = { path = "../rotala/" }
+dashmap = "6.1.0"
+env_logger = "0.10.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/rotala-http/src/bin/uist_server_v1.rs
+++ b/rotala-http/src/bin/uist_server_v1.rs
@@ -11,6 +11,7 @@ use rotala_http::http::uist_v1::{
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    env_logger::init();
     let args: Vec<String> = env::args().collect();
 
     let address: String = args[1].clone();

--- a/rotala-http/src/bin/uist_server_v2.rs
+++ b/rotala-http/src/bin/uist_server_v2.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::sync::Mutex;
 
 use actix_web::{web, App, HttpServer};
 use rotala::input::athena::Athena;
@@ -9,6 +8,7 @@ use std::path::Path;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    env_logger::init();
     let args: Vec<String> = env::args().collect();
 
     let address: String = args[1].clone();
@@ -18,7 +18,7 @@ async fn main() -> std::io::Result<()> {
     let source = Athena::from_file(file_path);
     let app_state = AppState::single("Test", source);
 
-    let uist_state = web::Data::new(Mutex::new(app_state));
+    let uist_state = web::Data::new(app_state);
 
     HttpServer::new(move || {
         App::new()

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::Display,
+    mem,
 };
 
 use serde::{Deserialize, Serialize};
@@ -159,8 +160,9 @@ impl UistV2 {
         self.order_buffer.push(order);
     }
 
-    pub fn insert_orders(&mut self, orders: &mut Vec<Order>) {
-        self.order_buffer.append(orders);
+    pub fn insert_orders(&mut self, mut orders: Vec<Order>) {
+        let mut orders = mem::take(&mut orders);
+        self.order_buffer.append(&mut orders);
     }
 
     pub fn tick(&mut self, quotes: &DateDepth, now: i64) -> (Vec<OrderResult>, Vec<InnerOrder>) {


### PR DESCRIPTION
[Root issue](https://github.com/calumrussell/rotala/issues/111)

* Backtest state is stored with dashmap/concurrent hashmap removing mutex lock on every request
* Backtest id tracker is AtomicU64 (if we can't CAS then we don't init and return to user)
* Removes &mut from uistv2 trait
* Removed copy on `insert_orders`

Python strategy isn't working but think this is logic bug so leaving.