### PR TITLE
111 http perf python fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.csv
 /.vscode
 Cargo.lock
+data/venv/
+rotala-python/venv/
+test_data/
+*__pycache__*

--- a/rotala-http/src/http/uist_v2.rs
+++ b/rotala-http/src/http/uist_v2.rs
@@ -85,7 +85,7 @@ impl AppState {
                 backtest.pos = new_pos;
 
                 let bbo = dataset.get_bbo(new_date).unwrap();
-                //TODO: shouldn't clone here
+                //Have to clone here because we can't mutate immutable dataset
                 let depth = dataset.get_quotes(&new_date).unwrap().clone();
 
                 return Some((has_next, executed_orders, inserted_orders, bbo, depth));
@@ -288,7 +288,6 @@ pub mod server {
         mut insert_order: web::Json<InsertOrderRequest>,
     ) -> Result<web::Json<()>, UistV2Error> {
         let (backtest_id,) = path.into_inner();
-        //TODO: shouldn't need clone here
         let take_orders = std::mem::take(&mut insert_order.orders);
         if let Some(()) = app.insert_orders(take_orders, backtest_id) {
             Ok(web::Json(()))

--- a/rotala-http/src/http/uist_v2.rs
+++ b/rotala-http/src/http/uist_v2.rs
@@ -71,8 +71,9 @@ impl AppState {
 
                 if let Some(quotes) = dataset.get_quotes(&curr_date) {
                     let mut res = backtest.exchange.tick(quotes, curr_date);
-                    executed_orders.append(&mut res.0);
-                    inserted_orders.append(&mut res.1);
+
+                    executed_orders = std::mem::take(&mut res.0);
+                    inserted_orders = std::mem::take(&mut res.1);
                 }
 
                 let new_pos = backtest.pos + 1;

--- a/rotala-http/src/http/uist_v2.rs
+++ b/rotala-http/src/http/uist_v2.rs
@@ -76,19 +76,25 @@ impl AppState {
                 }
 
                 let new_pos = backtest.pos + 1;
-                let new_date = *dataset.get_date(new_pos).unwrap();
-
-                if dataset.has_next(new_pos) {
-                    has_next = true;
-                    backtest.date = new_date;
+                if let Some(new_date) = (*dataset).get_date(new_pos) {
+                    if dataset.has_next(new_pos) {
+                        has_next = true;
+                        backtest.date = *new_date;
+                    }
+                    backtest.pos = new_pos;
+                    let bbo = dataset.get_bbo(new_date).unwrap();
+                    //Have to clone here because we can't mutate immutable dataset
+                    let depth = dataset.get_quotes(new_date).unwrap().clone();
+                    return Some((has_next, executed_orders, inserted_orders, bbo, depth));
+                } else {
+                    return Some((
+                        false,
+                        Vec::new(),
+                        Vec::new(),
+                        HashMap::new(),
+                        HashMap::new(),
+                    ));
                 }
-                backtest.pos = new_pos;
-
-                let bbo = dataset.get_bbo(new_date).unwrap();
-                //Have to clone here because we can't mutate immutable dataset
-                let depth = dataset.get_quotes(&new_date).unwrap().clone();
-
-                return Some((has_next, executed_orders, inserted_orders, bbo, depth));
             }
         }
         None

--- a/rotala-python/main.py
+++ b/rotala-python/main.py
@@ -61,6 +61,8 @@ if __name__ == "__main__":
 
     last_mid = -1
     while True:
+        brkr.tick()
+
         depth = brkr.latest_depth
         bid_grid, ask_grid = create_grid(depth)
 
@@ -68,12 +70,14 @@ if __name__ == "__main__":
         if last_mid == -1:
             last_mid = mid_price
 
+        mid_change = round(abs(last_mid - mid_price), 2)
+        last_mid = mid_price
+
         risk = risk_management(brkr.unexecuted_orders, brkr.get_current_value())
         if len(brkr.unexecuted_orders) == 0:
             [brkr.insert_order(order) for order in create_orders(bid_grid, ask_grid)]
         else:
-            mid_change = round(abs(last_mid - mid_price), 2)
-            if mid_change > 0.4:
+            if mid_change > 0.1:
                 # In practice, we want to look for overlapping levels so we don't need
                 # to clear whole book
                 for order_id in brkr.unexecuted_orders:
@@ -87,5 +91,3 @@ if __name__ == "__main__":
                     brkr.insert_order(order)
                     for order in create_orders(bid_grid, ask_grid)
                 ]
-
-        brkr.tick()

--- a/rotala-python/main.py
+++ b/rotala-python/main.py
@@ -51,7 +51,7 @@ def create_orders(bid_grid, ask_grid):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.CRITICAL)
 
     builder = BrokerBuilder()
     builder.init_dataset_name("Test")

--- a/rotala-python/src/broker.py
+++ b/rotala-python/src/broker.py
@@ -192,13 +192,13 @@ class Broker:
 
         curr_position = self.holdings[position]
         new_position = curr_position + chg
-        logger.info(
+        logger.debug(
             f"{self.backtest_id}-{self.ts} POSITION CHG: {position} {curr_position} -> {new_position}"
         )
         self.holdings[position] = new_position
 
     def _process_order_result(self, result: OrderResult):
-        logger.info(f"{self.backtest_id}-{self.ts} EXECUTED: {result}")
+        logger.debug(f"{self.backtest_id}-{self.ts} EXECUTED: {result}")
 
         if result.typ == OrderResultType.Buy or result.typ == OrderResultType.Sell:
             before_trade = self.cash
@@ -208,7 +208,7 @@ class Broker:
                 else self.cash + result.value
             )
 
-            logger.info(
+            logger.debug(
                 f"{self.backtest_id}-{self.ts} CASH: {before_trade} -> {after_trade}"
             )
             self.cash = after_trade
@@ -266,7 +266,7 @@ class Broker:
         logger.info(f"{self.backtest_id}-{self.ts} TICK")
 
         # Flush pending orders
-        logger.info(
+        logger.debug(
             f"{self.backtest_id}-{self.ts} INSERTING {len(self.pending_orders)} ORDER"
         )
         self.http.insert_orders(self.pending_orders)
@@ -294,5 +294,5 @@ class Broker:
                 self.ts = list(self.latest_quotes.values())[0]["date"]
 
         curr_value = self.get_current_value()
-        logger.info(f"{self.backtest_id}-{self.ts} TOTAL VALUE: {curr_value}")
+        logger.debug(f"{self.backtest_id}-{self.ts} TOTAL VALUE: {curr_value}")
         self.portfolio_values.append(curr_value)

--- a/rotala-python/src/broker.py
+++ b/rotala-python/src/broker.py
@@ -122,6 +122,7 @@ class OrderResult:
         date: int,
         typ: OrderResultType,
         order_id: int,
+        order_id_ref: int | None,
     ):
         self.symbol = symbol
         self.value = value
@@ -129,6 +130,7 @@ class OrderResult:
         self.date = date
         self.typ = typ
         self.order_id = order_id
+        self.order_id_ref = order_id_ref
 
     def __str__(self):
         return (
@@ -145,6 +147,7 @@ class OrderResult:
             from_dict["date"],
             trade_type,
             from_dict["order_id"],
+            from_dict["order_id_ref"],
         )
 
     @staticmethod
@@ -157,6 +160,7 @@ class OrderResult:
             to_dict["date"],
             to_dict["typ"],
             to_dict["order_id"],
+            to_dict["order_id_ref"],
         )
 
 
@@ -228,6 +232,7 @@ class Broker:
         else:
             if result.typ == OrderResultType.Cancel:
                 del self.unexecuted_orders[result.order_id]
+                del self.unexecuted_orders[result.order_id_ref]
             else:
                 logger.critical("Unsupported order modification type")
                 exit(1)

--- a/rotala/src/exchange/uist_v1.rs
+++ b/rotala/src/exchange/uist_v1.rs
@@ -168,6 +168,10 @@ impl UistV1 {
         }
     }
 
+    pub fn executed_trade_count(&self) -> usize {
+        self.trade_log.len()
+    }
+
     fn sort_order_buffer(&mut self) {
         self.order_buffer.sort_by(|a, _b| match a.get_order_type() {
             OrderType::LimitSell | OrderType::StopSell | OrderType::MarketSell => {
@@ -372,8 +376,7 @@ mod tests {
         exchange.tick(source.get_quotes_unchecked(&100));
         exchange.tick(source.get_quotes_unchecked(&101));
 
-        //TODO: no abstraction!
-        assert_eq!(exchange.trade_log.len(), 1);
+        assert_eq!(exchange.executed_trade_count(), 1);
     }
 
     #[test]
@@ -387,7 +390,7 @@ mod tests {
 
         exchange.tick(source.get_quotes_unchecked(&100));
         exchange.tick(source.get_quotes_unchecked(&101));
-        assert_eq!(exchange.trade_log.len(), 4);
+        assert_eq!(exchange.executed_trade_count(), 4);
     }
 
     #[test]
@@ -402,7 +405,7 @@ mod tests {
         exchange.tick(source.get_quotes_unchecked(&101));
         exchange.tick(source.get_quotes_unchecked(&102));
 
-        assert_eq!(exchange.trade_log.len(), 4);
+        assert_eq!(exchange.executed_trade_count(), 4);
     }
 
     #[test]
@@ -414,7 +417,7 @@ mod tests {
         exchange.tick(source.get_quotes_unchecked(&100));
         exchange.tick(source.get_quotes_unchecked(&101));
 
-        assert_eq!(exchange.trade_log.len(), 1);
+        assert_eq!(exchange.executed_trade_count(), 1);
         let trade = exchange.trade_log.remove(0);
         //Trade executes at 101 so trade price should be 103
         assert_eq!(trade.value / trade.quantity, 103.00);
@@ -430,7 +433,7 @@ mod tests {
         exchange.tick(source.get_quotes_unchecked(&100));
         exchange.tick(source.get_quotes_unchecked(&101));
 
-        assert_eq!(exchange.trade_log.len(), 1);
+        assert_eq!(exchange.executed_trade_count(), 1);
         let trade = exchange.trade_log.remove(0);
         //Trade executes at 101 so trade price should be 103
         assert_eq!(trade.value / trade.quantity, 102.00);
@@ -444,7 +447,7 @@ mod tests {
         exchange.insert_order(Order::market_buy("XYZ", 100.0));
         exchange.tick(source.get_quotes_unchecked(&100));
 
-        assert_eq!(exchange.trade_log.len(), 0);
+        assert_eq!(exchange.executed_trade_count(), 0);
     }
 
     #[test]
@@ -468,11 +471,11 @@ mod tests {
         exchange.insert_order(Order::market_buy("ABC", 100.0));
         exchange.tick(source.get_quotes_unchecked(&100));
         //Orderbook should have one order and trade log has no executed trades
-        assert_eq!(exchange.trade_log.len(), 0);
+        assert_eq!(exchange.executed_trade_count(), 0);
 
         exchange.tick(source.get_quotes_unchecked(&102));
         //Order should execute now
-        assert_eq!(exchange.trade_log.len(), 1);
+        assert_eq!(exchange.executed_trade_count(), 1);
     }
 
     #[test]

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -431,6 +431,7 @@ impl OrderBook {
                     date: depth.date,
                     typ: OrderResultType::Buy,
                     order_id: order.order_id,
+                    order_id_ref: None,
                 };
                 trades.push(trade);
                 filled.insert_fill(&order.symbol, ask, qty);
@@ -460,6 +461,7 @@ impl OrderBook {
                     date: depth.date,
                     typ: OrderResultType::Sell,
                     order_id: order.order_id,
+                    order_id_ref: None,
                 };
                 trades.push(trade);
                 filled.insert_fill(&order.symbol, bid, qty);

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -366,34 +366,35 @@ impl OrderBook {
     // Only returns a single `OrderResult` but we return a `Vec` for empty condition
     fn modify_order(
         now: i64,
-        order_to_modify: &InnerOrder,
+        modify_order: &InnerOrder,
         orderbook: &mut BTreeMap<OrderId, InnerOrder>,
     ) -> Vec<OrderResult> {
         let mut res = Vec::new();
 
-        if let Some(order) = orderbook.get_mut(&order_to_modify.order_id_ref.unwrap()) {
-            let qty_change = order_to_modify.qty;
+        if let Some(order_to_modify) = orderbook.get_mut(&modify_order.order_id_ref.unwrap()) {
+            let qty_change = modify_order.qty;
 
             if qty_change > 0.0 {
-                order.qty += qty_change;
+                order_to_modify.qty += qty_change;
             } else {
-                let qty_left = order.qty + qty_change;
+                let qty_left = order_to_modify.qty + qty_change;
                 if qty_left > 0.0 {
-                    order.qty += qty_change;
+                    order_to_modify.qty += qty_change;
                 } else {
                     // we are trying to remove more than the total number of shares
                     // left on the order so will assume user wants to cancel
-                    orderbook.remove(&order_to_modify.order_id);
+                    orderbook.remove(&modify_order.order_id);
                 }
             }
 
             let order_result = OrderResult {
-                symbol: order_to_modify.symbol.clone(),
+                symbol: modify_order.symbol.clone(),
                 value: 0.0,
                 quantity: 0.0,
                 date: now,
                 typ: OrderResultType::Modify,
-                order_id: order_to_modify.order_id,
+                order_id: modify_order.order_id,
+                order_id_ref: Some(modify_order.order_id_ref.unwrap()),
             };
             res.push(order_result);
         }

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -354,7 +354,7 @@ impl OrderBook {
                     date: now,
                     typ: OrderResultType::Cancel,
                     order_id: cancel_order.order_id,
-                    order_id_ref: Some(order_to_cancel_id.clone()),
+                    order_id_ref: Some(*order_to_cancel_id),
                 };
                 res.push(order_result);
             }

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -126,6 +126,7 @@ pub struct OrderResult {
     pub date: i64,
     pub typ: OrderResultType,
     pub order_id: OrderId,
+    pub order_id_ref: Option<OrderId>,
 }
 
 #[derive(Debug)]
@@ -339,20 +340,21 @@ impl OrderBook {
     // Only returns a single `OrderResult` but we return a `Vec` for empty condition
     fn cancel_order(
         now: i64,
-        order_to_cancel: &InnerOrder,
+        cancel_order: &InnerOrder,
         orderbook: &mut BTreeMap<OrderId, InnerOrder>,
     ) -> Vec<OrderResult> {
         let mut res = Vec::new();
         //Fails silently if you send garbage in
-        if let Some(order_id) = &order_to_cancel.order_id_ref {
-            if orderbook.remove(order_id).is_some() {
+        if let Some(order_to_cancel_id) = &cancel_order.order_id_ref {
+            if orderbook.remove(order_to_cancel_id).is_some() {
                 let order_result = OrderResult {
-                    symbol: order_to_cancel.symbol.clone(),
+                    symbol: cancel_order.symbol.clone(),
                     value: 0.0,
                     quantity: 0.0,
                     date: now,
                     typ: OrderResultType::Cancel,
-                    order_id: order_to_cancel.order_id,
+                    order_id: cancel_order.order_id,
+                    order_id_ref: Some(order_to_cancel_id.clone()),
                 };
                 res.push(order_result);
             }

--- a/rotala/src/input/athena.rs
+++ b/rotala/src/input/athena.rs
@@ -94,8 +94,6 @@ pub type DateBBO = HashMap<String, BBO>;
 
 pub struct Athena {
     dates: Vec<i64>,
-    //TODO: this is not great, added because the dates weren't being added at all, not sure if this
-    //is really ideal path
     dates_seen: HashSet<i64>,
     inner: HashMap<i64, DateDepth>,
 }

--- a/rotala/src/input/athena.rs
+++ b/rotala/src/input/athena.rs
@@ -136,7 +136,6 @@ impl Athena {
         Some(res)
     }
 
-
     pub fn sort_dates(&mut self) {
         self.dates.sort()
     }

--- a/rotala/src/input/athena.rs
+++ b/rotala/src/input/athena.rs
@@ -136,6 +136,11 @@ impl Athena {
         Some(res)
     }
 
+
+    pub fn sort_dates(&mut self) {
+        self.dates.sort()
+    }
+
     pub fn add_depth(&mut self, depth: Depth) {
         let date = depth.date;
         let symbol = depth.symbol.clone();
@@ -222,6 +227,7 @@ impl Athena {
             let into_depth: Depth = value.into();
             athena.add_depth(into_depth);
         }
+        athena.sort_dates();
         athena
     }
 


### PR DESCRIPTION
[Root issue](https://github.com/calumrussell/rotala/issues/111)

* Reduce the number of clones in exchange/http
* Use mem::take to reduce additional memory allocations
* Fix bug with data ingest where input was unsorted
* Fix bug with Python client that led to order inflation by adding order_ref_id to OrderResult
* Fix bug with last tick in http
* Fix bug with Python client where mid_price wasn't updating correctly which led to Cancel orders
* Python reuses HTTP connection improving perf
* Made logging levels more useful in Python

Doing 1666 ticks per second.