### PR TITLE
112 tick returns time

### DIFF
--- a/rotala-client/src/client/uist_v2.rs
+++ b/rotala-client/src/client/uist_v2.rs
@@ -126,6 +126,7 @@ impl Client for TestClient {
                 inserted_orders: resp.2,
                 executed_orders: resp.1,
                 has_next: resp.0,
+                now: resp.5,
             }))
         } else {
             future::ready(Err(Error::new(UistV2Error::UnknownBacktest)))

--- a/rotala-http/src/http/uist_v2.rs
+++ b/rotala-http/src/http/uist_v2.rs
@@ -11,7 +11,14 @@ use rotala::exchange::uist_v2::{InnerOrder, Order, OrderId, OrderResult, UistV2}
 use rotala::input::athena::{Athena, DateBBO, DateDepth};
 
 pub type BacktestId = u64;
-pub type TickResponseType = (bool, Vec<OrderResult>, Vec<InnerOrder>, DateBBO, DateDepth);
+pub type TickResponseType = (
+    bool,
+    Vec<OrderResult>,
+    Vec<InnerOrder>,
+    DateBBO,
+    DateDepth,
+    i64,
+);
 
 pub struct BacktestState {
     pub id: BacktestId,
@@ -77,6 +84,7 @@ impl AppState {
                         Vec::new(),
                         HashMap::new(),
                         HashMap::new(),
+                        new_date,
                     ));
                 } else {
                     let bbo = dataset
@@ -93,7 +101,7 @@ impl AppState {
                     };
 
                     backtest.curr_date = new_date;
-                    return Some((true, executed_orders, inserted_orders, bbo, depth));
+                    return Some((true, executed_orders, inserted_orders, bbo, depth, new_date));
                 }
             }
         }
@@ -182,6 +190,7 @@ pub struct TickResponse {
     pub inserted_orders: Vec<InnerOrder>,
     pub bbo: DateBBO,
     pub depth: DateDepth,
+    pub now: i64,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -297,6 +306,7 @@ pub mod server {
                 inserted_orders: result.2,
                 executed_orders: result.1,
                 has_next: result.0,
+                now: result.5,
             }))
         } else {
             Err(UistV2Error::UnknownBacktest)

--- a/rotala-python/main.py
+++ b/rotala-python/main.py
@@ -55,16 +55,18 @@ if __name__ == "__main__":
 
     dataset_name = "Test"
     frequency = 250
+    sim_length = frequency * 10000
     http_client = HttpClient("http://127.0.0.1:3000")
     dataset_info = http_client.dataset_info(dataset_name)
+    start_date = dataset_info["start_date"]
 
     builder = BrokerBuilder()
     builder.init_dataset_name(dataset_name)
     builder.init_cash(100000)
     builder.init_http(http_client)
     #Clear the first date so we have quotes always
-    builder.init_dates(dataset_info["start_date"]+250, dataset_info["end_date"])
-    builder.init_frequency(250)
+    builder.init_dates(start_date+frequency, start_date+frequency+sim_length)
+    builder.init_frequency(frequency)
     brkr = builder.build()
 
     last_mid = -1

--- a/rotala-python/src/broker.py
+++ b/rotala-python/src/broker.py
@@ -308,8 +308,8 @@ class Broker:
             if self.latest_quotes:
                 self.cached_quotes = self.latest_quotes
             self.latest_depth = tick_response["depth"]
-            if self.latest_quotes:
-                self.ts = list(self.latest_quotes.values())[0]["date"]
+
+        self.ts = tick_response["now"]
 
         curr_value = self.get_current_value()
         logger.debug(f"{self.backtest_id}-{self.ts} TOTAL VALUE: {curr_value}")

--- a/rotala-python/src/http.py
+++ b/rotala-python/src/http.py
@@ -57,13 +57,6 @@ class HttpClient:
         r = self.s.get(f"{self.base_url}/backtest/{self.backtest_id}/info")
         return r.json()
 
-    def now(self):
-        if self.backtest_id is None:
-            raise ValueError("Called before init")
-
-        r = self.s.get(f"{self.base_url}/backtest/{self.backtest_id}/now")
-        return r.json()
-
     def dataset_info(self, dataset):
         r = self.s.get(f"{self.base_url}/dataset/{dataset}/info")
         return r.json()


### PR DESCRIPTION
[Root issue](https://github.com/calumrussell/rotala/issues/112)

* Deleted now route
* Tick returns time
* Python client now has time set correctly on every tick

Seems to have been perf regression somewhere, doing 1k ticks per second.