### PR TITLE
112 exchange logic includes trades

### DIFF
--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -429,14 +429,14 @@ impl OrderBook {
         let is_buy = match order.order_type {
             OrderType::MarketBuy | OrderType::LimitBuy => true,
             OrderType::LimitSell | OrderType::MarketSell => false,
-            _ => panic!("Can't fill cancel or modify")
+            _ => panic!("Can't fill cancel or modify"),
         };
 
         let price_check = match order.order_type {
             OrderType::LimitBuy | OrderType::LimitSell => order.price.unwrap(),
             OrderType::MarketBuy => f64::MAX,
             OrderType::MarketSell => f64::MIN,
-            _ => panic!("Can't fill cancel or modify")
+            _ => panic!("Can't fill cancel or modify"),
         };
 
         for bid in &depth.bids {
@@ -475,7 +475,6 @@ impl OrderBook {
                 if size == 0.0 {
                     break;
                 }
-
 
                 let qty = if size >= to_fill { to_fill } else { size };
                 to_fill -= qty;
@@ -628,11 +627,11 @@ impl OrderBook {
             if let Some(depth) = quotes.get(security_id) {
                 let mut completed_trades = match order.order_type {
                     OrderType::MarketBuy => Self::fill_order(
-                        depth, 
-                        &order, 
-                        &mut filled, 
-                        &taker_trades, 
-                        &self.priority_setting
+                        depth,
+                        &order,
+                        &mut filled,
+                        &taker_trades,
+                        &self.priority_setting,
                     ),
                     OrderType::MarketSell => Self::fill_order(
                         depth,
@@ -954,7 +953,7 @@ mod tests {
             time: 100,
         };
         let ask_trade = Trade {
-           coin: "ABC".to_string(),
+            coin: "ABC".to_string(),
             side: Side::Ask,
             px: 102.0,
             sz: 80.0,

--- a/rotala/src/input/minerva.rs
+++ b/rotala/src/input/minerva.rs
@@ -130,8 +130,7 @@ impl Minerva {
 
                     res.entry(hl_trade.time).or_insert_with(Vec::new);
 
-                    let date_trades = res.get_mut(&hl_trade.time)
-                        .unwrap();
+                    let date_trades = res.get_mut(&hl_trade.time).unwrap();
                     date_trades.push(hl_trade);
                 }
             }

--- a/rotala/src/source/hyperliquid.rs
+++ b/rotala/src/source/hyperliquid.rs
@@ -184,4 +184,4 @@ pub struct Trade {
 
 pub type DateDepth = BTreeMap<String, Depth>;
 pub type DateBBO = BTreeMap<String, BBO>;
-pub type DateTrade = BTreeMap<i64, Trade>;
+pub type DateTrade = BTreeMap<i64, Vec<Trade>>;


### PR DESCRIPTION
[Root issue](https://github.com/calumrussell/rotala/issues/112)

Existing v2 exchange takes depth as an input. This means that volume can't be traded on the inside and trades are only booked once the level is traded through completely. Fills can, therefore, be multiple ticks out.

By including trades, we look at volume filled (typically on the inside) and can lift from there.

This approach is the opposite of the conservative approach because it assumes that we are top of the queue. So this behaviour should be a user-controlled parameter: trade-through, and priority.