### PR TITLE
Fixes bug when lifting multiple levels and in Minerva depth dataset

### DIFF
--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -458,7 +458,7 @@ impl OrderBook {
 
                         let trade = OrderResult {
                             symbol: order.symbol.clone(),
-                            value: bid.price * order.qty,
+                            value: bid.price * qty,
                             quantity: qty,
                             date: depth.date,
                             typ: OrderResultType::Buy,
@@ -483,13 +483,14 @@ impl OrderBook {
                 to_fill -= qty;
                 let trade = OrderResult {
                     symbol: order.symbol.clone(),
-                    value: bid.price * order.qty,
+                    value: bid.price * qty,
                     quantity: qty,
                     date: depth.date,
                     typ: OrderResultType::Sell,
                     order_id: order.order_id,
                     order_id_ref: None,
                 };
+
                 trades.push(trade);
                 filled.insert_fill(&order.symbol, &bid.price, qty);
 
@@ -515,7 +516,7 @@ impl OrderBook {
 
                         let trade = OrderResult {
                             symbol: order.symbol.clone(),
-                            value: ask.price * order.qty,
+                            value: ask.price * qty,
                             quantity: qty,
                             date: depth.date,
                             typ: OrderResultType::Sell,
@@ -540,7 +541,7 @@ impl OrderBook {
                 to_fill -= qty;
                 let trade = OrderResult {
                     symbol: order.symbol.clone(),
-                    value: ask.price * order.qty,
+                    value: ask.price * qty,
                     quantity: qty,
                     date: depth.date,
                     typ: OrderResultType::Buy,

--- a/rotala/src/input/minerva.rs
+++ b/rotala/src/input/minerva.rs
@@ -108,6 +108,9 @@ impl Minerva {
                 )
                 .await;
 
+            //TODO: there is a bug here, this is putting all of the rows for a date under a symbol
+            //so SOL will have levels for HYPE if they share a quote date. Think this explains
+            //sparsity of quotes.
             let mut sort_into_dates = HashMap::new();
             if let Ok(rows) = query_result {
                 for row in rows {

--- a/rotala/src/input/minerva.rs
+++ b/rotala/src/input/minerva.rs
@@ -112,10 +112,7 @@ impl Minerva {
             if let Ok(rows) = query_result {
                 for row in rows {
                     if let Ok(book) = L2Book::from_row(row) {
-
-                        if !sort_into_dates.contains_key(&book.time) {
-                            sort_into_dates.insert(book.time, HashMap::new());
-                        }
+                        sort_into_dates.entry(book.time).or_default();
 
                         let date = sort_into_dates.get_mut(&book.time).unwrap();
 
@@ -131,7 +128,6 @@ impl Minerva {
 
             for (date, coin_map) in sort_into_dates.iter_mut() {
                 for (coin, book) in coin_map.iter_mut() {
-
                     let depth: Depth = std::mem::take(book).into();
 
                     self.depths.entry(*date).or_default();


### PR DESCRIPTION
When lifting multiple levels, the qty for the trade was the original qty rather than the remaining size after the first trade.

Minerva depth was, in some cases, merging bid/ask across symbols.