### PR TITLE
Adding support for multiple exchanges

### DIFF
--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -133,6 +133,7 @@ pub struct OrderResult {
     pub typ: OrderResultType,
     pub order_id: OrderId,
     pub order_id_ref: Option<OrderId>,
+    pub exchange: String,
 }
 
 #[derive(Debug)]
@@ -380,6 +381,7 @@ impl OrderBook {
                     typ: OrderResultType::Cancel,
                     order_id: cancel_order.order_id,
                     order_id_ref: Some(*order_to_cancel_id),
+                    exchange: cancel_order.exchange.clone(),
                 };
                 res.push(order_result);
             }
@@ -420,6 +422,7 @@ impl OrderBook {
                 typ: OrderResultType::Modify,
                 order_id: modify_order.order_id,
                 order_id_ref: Some(modify_order.order_id_ref.unwrap()),
+                exchange: modify_order.exchange.clone(),
             };
             res.push(order_result);
         }
@@ -471,6 +474,7 @@ impl OrderBook {
                             typ: OrderResultType::Buy,
                             order_id: order.order_id,
                             order_id_ref: None,
+                            exchange: order.exchange.clone(),
                         };
 
                         trades.push(trade);
@@ -496,6 +500,7 @@ impl OrderBook {
                     typ: OrderResultType::Sell,
                     order_id: order.order_id,
                     order_id_ref: None,
+                    exchange: order.exchange.clone(),
                 };
 
                 trades.push(trade);
@@ -529,6 +534,7 @@ impl OrderBook {
                             typ: OrderResultType::Sell,
                             order_id: order.order_id,
                             order_id_ref: None,
+                            exchange: order.exchange.clone(),
                         };
 
                         trades.push(trade);
@@ -554,6 +560,7 @@ impl OrderBook {
                     typ: OrderResultType::Buy,
                     order_id: order.order_id,
                     order_id_ref: None,
+                    exchange: order.exchange.clone(),
                 };
                 trades.push(trade);
                 filled.insert_fill(&order.symbol, &ask.price, qty);

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -55,7 +55,12 @@ pub struct Order {
 }
 
 impl Order {
-    fn market(order_type: OrderType, symbol: impl Into<String>, shares: f64, exchange: impl Into<String>) -> Self {
+    fn market(
+        order_type: OrderType,
+        symbol: impl Into<String>,
+        shares: f64,
+        exchange: impl Into<String>,
+    ) -> Self {
         Self {
             order_type,
             symbol: symbol.into(),
@@ -66,14 +71,20 @@ impl Order {
         }
     }
 
-    fn delayed(order_type: OrderType, symbol: impl Into<String>, shares: f64, price: f64, exchange: impl Into<String>) -> Self {
+    fn delayed(
+        order_type: OrderType,
+        symbol: impl Into<String>,
+        shares: f64,
+        price: f64,
+        exchange: impl Into<String>,
+    ) -> Self {
         Self {
             order_type,
             symbol: symbol.into(),
             qty: shares,
             price: Some(price),
             order_id_ref: None,
-            exchange: exchange.into()
+            exchange: exchange.into(),
         }
     }
 
@@ -81,19 +92,38 @@ impl Order {
         Order::market(OrderType::MarketBuy, symbol, shares, exchange)
     }
 
-    pub fn market_sell(symbol: impl Into<String>, shares: f64, exchange: impl Into<String>) -> Self {
+    pub fn market_sell(
+        symbol: impl Into<String>,
+        shares: f64,
+        exchange: impl Into<String>,
+    ) -> Self {
         Order::market(OrderType::MarketSell, symbol, shares, exchange)
     }
 
-    pub fn limit_buy(symbol: impl Into<String>, shares: f64, price: f64, exchange: impl Into<String>) -> Self {
+    pub fn limit_buy(
+        symbol: impl Into<String>,
+        shares: f64,
+        price: f64,
+        exchange: impl Into<String>,
+    ) -> Self {
         Order::delayed(OrderType::LimitBuy, symbol, shares, price, exchange)
     }
 
-    pub fn limit_sell(symbol: impl Into<String>, shares: f64, price: f64, exchange: impl Into<String>) -> Self {
+    pub fn limit_sell(
+        symbol: impl Into<String>,
+        shares: f64,
+        price: f64,
+        exchange: impl Into<String>,
+    ) -> Self {
         Order::delayed(OrderType::LimitSell, symbol, shares, price, exchange)
     }
 
-    pub fn modify_order(symbol: impl Into<String>, order_id: OrderId, qty_change: f64, exchange: impl Into<String>) -> Self {
+    pub fn modify_order(
+        symbol: impl Into<String>,
+        order_id: OrderId,
+        qty_change: f64,
+        exchange: impl Into<String>,
+    ) -> Self {
         Self {
             order_id_ref: Some(order_id),
             order_type: OrderType::Modify,
@@ -104,14 +134,18 @@ impl Order {
         }
     }
 
-    pub fn cancel_order(symbol: impl Into<String>, order_id: OrderId, exchange: impl Into<String>) -> Self {
+    pub fn cancel_order(
+        symbol: impl Into<String>,
+        order_id: OrderId,
+        exchange: impl Into<String>,
+    ) -> Self {
         Self {
             order_id_ref: Some(order_id),
             order_type: OrderType::Cancel,
             symbol: symbol.into(),
             price: None,
             qty: 0.0,
-            exchange: exchange.into()
+            exchange: exchange.into(),
         }
     }
 }
@@ -641,7 +675,7 @@ impl OrderBook {
                 unexecuted_orders.insert(order_id, order);
                 continue;
             }
-            
+
             if let Some(exchange) = quotes.get(&order.exchange) {
                 if let Some(depth) = exchange.get(security_id) {
                     let mut completed_trades = match order.order_type {
@@ -683,7 +717,6 @@ impl OrderBook {
 
                     trade_results.append(&mut completed_trades)
                 }
-
             } else {
                 unexecuted_orders.insert(order_id, order);
             }
@@ -743,7 +776,10 @@ mod tests {
 
         let mut quotes: DateDepth = BTreeMap::new();
         quotes.insert("exchange".to_string(), BTreeMap::new());
-        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
+        quotes
+            .get_mut("exchange")
+            .unwrap()
+            .insert("ABC".to_string(), depth);
         quotes
     }
 
@@ -788,7 +824,10 @@ mod tests {
 
         let mut quotes: DateDepth = BTreeMap::new();
         quotes.insert("exchange".to_string(), BTreeMap::new());
-        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
+        quotes
+            .get_mut("exchange")
+            .unwrap()
+            .insert("ABC".to_string(), depth);
         quotes
     }
 
@@ -906,7 +945,10 @@ mod tests {
 
         let mut quotes: DateDepth = BTreeMap::new();
         quotes.insert("exchange".to_string(), BTreeMap::new());
-        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
+        quotes
+            .get_mut("exchange")
+            .unwrap()
+            .insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -973,7 +1015,10 @@ mod tests {
 
         let mut quotes: DateDepth = BTreeMap::new();
         quotes.insert("exchange".to_string(), BTreeMap::new());
-        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
+        quotes
+            .get_mut("exchange")
+            .unwrap()
+            .insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -1041,7 +1086,10 @@ mod tests {
 
         let mut quotes: DateDepth = BTreeMap::new();
         quotes.insert("exchange".to_string(), BTreeMap::new());
-        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
+        quotes
+            .get_mut("exchange")
+            .unwrap()
+            .insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -1261,7 +1309,10 @@ mod tests {
 
         let mut quotes: DateDepth = BTreeMap::new();
         quotes.insert("exchange".to_string(), BTreeMap::new());
-        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
+        quotes
+            .get_mut("exchange")
+            .unwrap()
+            .insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -1311,7 +1362,10 @@ mod tests {
 
         let mut quotes: DateDepth = BTreeMap::new();
         quotes.insert("exchange".to_string(), BTreeMap::new());
-        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
+        quotes
+            .get_mut("exchange")
+            .unwrap()
+            .insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),

--- a/rotala/src/exchange/uist_v2.rs
+++ b/rotala/src/exchange/uist_v2.rs
@@ -51,62 +51,67 @@ pub struct Order {
     pub qty: f64,
     pub price: Option<f64>,
     pub order_id_ref: Option<OrderId>,
+    pub exchange: String,
 }
 
 impl Order {
-    fn market(order_type: OrderType, symbol: impl Into<String>, shares: f64) -> Self {
+    fn market(order_type: OrderType, symbol: impl Into<String>, shares: f64, exchange: impl Into<String>) -> Self {
         Self {
             order_type,
             symbol: symbol.into(),
             qty: shares,
             price: None,
             order_id_ref: None,
+            exchange: exchange.into(),
         }
     }
 
-    fn delayed(order_type: OrderType, symbol: impl Into<String>, shares: f64, price: f64) -> Self {
+    fn delayed(order_type: OrderType, symbol: impl Into<String>, shares: f64, price: f64, exchange: impl Into<String>) -> Self {
         Self {
             order_type,
             symbol: symbol.into(),
             qty: shares,
             price: Some(price),
             order_id_ref: None,
+            exchange: exchange.into()
         }
     }
 
-    pub fn market_buy(symbol: impl Into<String>, shares: f64) -> Self {
-        Order::market(OrderType::MarketBuy, symbol, shares)
+    pub fn market_buy(symbol: impl Into<String>, shares: f64, exchange: impl Into<String>) -> Self {
+        Order::market(OrderType::MarketBuy, symbol, shares, exchange)
     }
 
-    pub fn market_sell(symbol: impl Into<String>, shares: f64) -> Self {
-        Order::market(OrderType::MarketSell, symbol, shares)
+    pub fn market_sell(symbol: impl Into<String>, shares: f64, exchange: impl Into<String>) -> Self {
+        Order::market(OrderType::MarketSell, symbol, shares, exchange)
     }
 
-    pub fn limit_buy(symbol: impl Into<String>, shares: f64, price: f64) -> Self {
-        Order::delayed(OrderType::LimitBuy, symbol, shares, price)
+    pub fn limit_buy(symbol: impl Into<String>, shares: f64, price: f64, exchange: impl Into<String>) -> Self {
+        Order::delayed(OrderType::LimitBuy, symbol, shares, price, exchange)
     }
 
-    pub fn limit_sell(symbol: impl Into<String>, shares: f64, price: f64) -> Self {
-        Order::delayed(OrderType::LimitSell, symbol, shares, price)
+    pub fn limit_sell(symbol: impl Into<String>, shares: f64, price: f64, exchange: impl Into<String>) -> Self {
+        Order::delayed(OrderType::LimitSell, symbol, shares, price, exchange)
     }
 
-    pub fn modify_order(symbol: impl Into<String>, order_id: OrderId, qty_change: f64) -> Self {
+    pub fn modify_order(symbol: impl Into<String>, order_id: OrderId, qty_change: f64, exchange: impl Into<String>) -> Self {
         Self {
             order_id_ref: Some(order_id),
             order_type: OrderType::Modify,
             symbol: symbol.into(),
             price: None,
             qty: qty_change,
+            exchange: exchange.into(),
         }
     }
 
-    pub fn cancel_order(symbol: impl Into<String>, order_id: OrderId) -> Self {
+    pub fn cancel_order(symbol: impl Into<String>, order_id: OrderId, exchange: impl Into<String>) -> Self {
         Self {
             order_id_ref: Some(order_id),
             order_type: OrderType::Cancel,
             symbol: symbol.into(),
             price: None,
             qty: 0.0,
+            exchange: exchange.into()
         }
     }
 }
@@ -267,6 +272,7 @@ pub struct InnerOrder {
     pub recieved_timestamp: i64,
     pub order_id: OrderId,
     pub order_id_ref: Option<OrderId>,
+    pub exchange: String,
 }
 
 #[derive(Debug)]
@@ -344,6 +350,7 @@ impl OrderBook {
             qty: order.qty,
             price: order.price,
             order_id_ref: order.order_id_ref,
+            exchange: order.exchange,
         };
 
         self.inner.insert(self.last_order_id, inner_order.clone());
@@ -627,46 +634,49 @@ impl OrderBook {
                 unexecuted_orders.insert(order_id, order);
                 continue;
             }
+            
+            if let Some(exchange) = quotes.get(&order.exchange) {
+                if let Some(depth) = exchange.get(security_id) {
+                    let mut completed_trades = match order.order_type {
+                        OrderType::MarketBuy => Self::fill_order(
+                            depth,
+                            &order,
+                            &mut filled,
+                            &taker_trades,
+                            &self.priority_setting,
+                        ),
+                        OrderType::MarketSell => Self::fill_order(
+                            depth,
+                            &order,
+                            &mut filled,
+                            &taker_trades,
+                            &self.priority_setting,
+                        ),
+                        OrderType::LimitBuy => Self::fill_order(
+                            depth,
+                            &order,
+                            &mut filled,
+                            &taker_trades,
+                            &self.priority_setting,
+                        ),
+                        OrderType::LimitSell => Self::fill_order(
+                            depth,
+                            &order,
+                            &mut filled,
+                            &taker_trades,
+                            &self.priority_setting,
+                        ),
+                        // There shouldn't be any cancel or modifies by this point
+                        _ => vec![],
+                    };
 
-            if let Some(depth) = quotes.get(security_id) {
-                let mut completed_trades = match order.order_type {
-                    OrderType::MarketBuy => Self::fill_order(
-                        depth,
-                        &order,
-                        &mut filled,
-                        &taker_trades,
-                        &self.priority_setting,
-                    ),
-                    OrderType::MarketSell => Self::fill_order(
-                        depth,
-                        &order,
-                        &mut filled,
-                        &taker_trades,
-                        &self.priority_setting,
-                    ),
-                    OrderType::LimitBuy => Self::fill_order(
-                        depth,
-                        &order,
-                        &mut filled,
-                        &taker_trades,
-                        &self.priority_setting,
-                    ),
-                    OrderType::LimitSell => Self::fill_order(
-                        depth,
-                        &order,
-                        &mut filled,
-                        &taker_trades,
-                        &self.priority_setting,
-                    ),
-                    // There shouldn't be any cancel or modifies by this point
-                    _ => vec![],
-                };
+                    if completed_trades.is_empty() {
+                        unexecuted_orders.insert(order_id, order);
+                    }
 
-                if completed_trades.is_empty() {
-                    unexecuted_orders.insert(order_id, order);
+                    trade_results.append(&mut completed_trades)
                 }
 
-                trade_results.append(&mut completed_trades)
             } else {
                 unexecuted_orders.insert(order_id, order);
             }
@@ -692,6 +702,7 @@ mod tests {
             px: 100.0,
             sz: 100.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -699,6 +710,7 @@ mod tests {
             px: 102.0,
             sz: 100.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
@@ -718,12 +730,13 @@ mod tests {
             size: 100.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level, Side::Bid);
         depth.add_level(ask_level, Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
         quotes
     }
 
@@ -734,6 +747,7 @@ mod tests {
             px: 98.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -741,6 +755,7 @@ mod tests {
             px: 102.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
@@ -760,13 +775,13 @@ mod tests {
             size: 20.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level, Side::Bid);
         depth.add_level(ask_level, Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
-
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
         quotes
     }
 
@@ -775,7 +790,7 @@ mod tests {
         let quotes = quotes();
         let trades = trades();
         let mut orderbook = OrderBook::new();
-        orderbook.insert_order(Order::cancel_order("ABC", 10), 100);
+        orderbook.insert_order(Order::cancel_order("ABC", 10, "exchange"), 100);
         let res = orderbook.execute_orders(&quotes, &trades, 100);
         assert!(res.is_empty())
     }
@@ -785,7 +800,7 @@ mod tests {
         let quotes = quotes();
         let trades = trades();
         let mut orderbook = OrderBook::new();
-        orderbook.insert_order(Order::modify_order("ABC", 10, 100.0), 100);
+        orderbook.insert_order(Order::modify_order("ABC", 10, 100.0, "exchange"), 100);
         let res = orderbook.execute_orders(&quotes, &trades, 100);
         assert!(res.is_empty())
     }
@@ -797,18 +812,18 @@ mod tests {
 
         let mut orderbook = OrderBook::new();
         let oid = orderbook
-            .insert_order(Order::limit_buy("ABC", 100.0, 1.0), 100)
+            .insert_order(Order::limit_buy("ABC", 100.0, 1.0, "exchange"), 100)
             .order_id;
 
-        orderbook.insert_order(Order::cancel_order("ABC", oid), 100);
+        orderbook.insert_order(Order::cancel_order("ABC", oid, "exchange"), 100);
         let res = orderbook.execute_orders(&quotes, &trades, 100);
         println!("{:?}", res);
         assert!(res.len() == 1);
 
         let oid1 = orderbook
-            .insert_order(Order::limit_buy("ABC", 200.0, 1.0), 100)
+            .insert_order(Order::limit_buy("ABC", 200.0, 1.0, "exchange"), 100)
             .order_id;
-        orderbook.insert_order(Order::modify_order("ABC", oid1, 100.0), 100);
+        orderbook.insert_order(Order::modify_order("ABC", oid1, 100.0, "exchange"), 100);
         let res = orderbook.execute_orders(&quotes, &trades, 100);
         assert!(res.len() == 1);
     }
@@ -819,7 +834,7 @@ mod tests {
         let trades = trades();
 
         let mut orderbook = OrderBook::new();
-        let order = Order::market_buy("ABC", 100.0);
+        let order = Order::market_buy("ABC", 100.0, "exchange");
         orderbook.insert_order(order, 100);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);
@@ -835,7 +850,7 @@ mod tests {
         let trades = trades();
 
         let mut orderbook = OrderBook::new();
-        let order = Order::market_sell("ABC", 100.0);
+        let order = Order::market_sell("ABC", 100.0, "exchange");
         orderbook.insert_order(order, 100);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);
@@ -850,7 +865,7 @@ mod tests {
         let quotes = quotes();
         let trades = trades();
         let mut orderbook = OrderBook::new();
-        let order = Order::market_buy("ABC", 50.0);
+        let order = Order::market_buy("ABC", 50.0, "exchange");
         orderbook.insert_order(order, 100);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);
@@ -877,13 +892,14 @@ mod tests {
             size: 20.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level, Side::Bid);
         depth.add_level(ask_level, Side::Ask);
         depth.add_level(ask_level_1, Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -891,6 +907,7 @@ mod tests {
             px: 100.0,
             sz: 100.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -898,13 +915,14 @@ mod tests {
             px: 102.0,
             sz: 80.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
         trades.insert(100, vec![bid_trade, ask_trade]);
 
         let mut orderbook = OrderBook::new();
-        let order = Order::market_buy("ABC", 100.0);
+        let order = Order::market_buy("ABC", 100.0, "exchange");
         orderbook.insert_order(order, 100);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);
@@ -940,14 +958,15 @@ mod tests {
             size: 20.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level, Side::Bid);
         depth.add_level(ask_level, Side::Ask);
         depth.add_level(ask_level_1, Side::Ask);
         depth.add_level(ask_level_2, Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -955,6 +974,7 @@ mod tests {
             px: 100.0,
             sz: 100.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -962,13 +982,14 @@ mod tests {
             px: 102.0,
             sz: 80.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
         trades.insert(100, vec![bid_trade, ask_trade]);
 
         let mut orderbook = OrderBook::new();
-        let order = Order::limit_buy("ABC", 120.0, 103.00);
+        let order = Order::limit_buy("ABC", 120.0, 103.00, "exchange");
         orderbook.insert_order(order, 100);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);
@@ -1005,14 +1026,15 @@ mod tests {
             size: 80.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level_0, Side::Bid);
         depth.add_level(bid_level_1, Side::Bid);
         depth.add_level(bid_level_2, Side::Bid);
         depth.add_level(ask_level, Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -1020,6 +1042,7 @@ mod tests {
             px: 100.0,
             sz: 80.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -1027,13 +1050,14 @@ mod tests {
             px: 102.0,
             sz: 80.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
         trades.insert(100, vec![bid_trade, ask_trade]);
 
         let mut orderbook = OrderBook::new();
-        let order = Order::limit_sell("ABC", 120.0, 99.00);
+        let order = Order::limit_sell("ABC", 120.0, 99.00, "exchange");
         orderbook.insert_order(order, 100);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);
@@ -1053,9 +1077,9 @@ mod tests {
         let quotes = quotes1();
         let trades = trades1();
         let mut orderbook = OrderBook::new();
-        let first_order = Order::limit_buy("ABC", 20.0, 103.00);
+        let first_order = Order::limit_buy("ABC", 20.0, 103.00, "exchange");
         orderbook.insert_order(first_order, 100);
-        let second_order = Order::limit_buy("ABC", 20.0, 103.00);
+        let second_order = Order::limit_buy("ABC", 20.0, 103.00, "exchange");
         orderbook.insert_order(second_order, 100);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);
@@ -1075,22 +1099,24 @@ mod tests {
             size: 20.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level.clone(), Side::Bid);
         depth.add_level(ask_level.clone(), Side::Ask);
 
-        let mut depth_101 = Depth::new(101, "ABC");
+        let mut depth_101 = Depth::new(101, "ABC", "exchange");
         depth_101.add_level(bid_level.clone(), Side::Bid);
         depth_101.add_level(ask_level.clone(), Side::Ask);
 
-        let mut depth_102 = Depth::new(102, "ABC");
+        let mut depth_102 = Depth::new(102, "ABC", "exchange");
         depth_102.add_level(bid_level, Side::Bid);
         depth_102.add_level(ask_level, Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
-        quotes.insert("ABC".to_string(), depth_101);
-        quotes.insert("ABC".to_string(), depth_102);
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        let exchange = quotes.get_mut("exchange").unwrap();
+        exchange.insert("ABC".to_string(), depth);
+        exchange.insert("ABC".to_string(), depth_101);
+        exchange.insert("ABC".to_string(), depth_102);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -1098,6 +1124,7 @@ mod tests {
             px: 98.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -1105,13 +1132,14 @@ mod tests {
             px: 102.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
         trades.insert(100, vec![bid_trade, ask_trade]);
 
         let mut orderbook = OrderBook::with_latency(1);
-        let order = Order::limit_buy("ABC", 20.0, 103.00);
+        let order = Order::limit_buy("ABC", 20.0, 103.00, "exchange");
         orderbook.insert_order(order, 100);
 
         let trades_100 = orderbook.execute_orders(&quotes, &trades, 100);
@@ -1130,7 +1158,7 @@ mod tests {
         let quotes = quotes1();
         let trades = trades1();
         let mut orderbook = OrderBook::new();
-        let order = Order::market_buy("ABC", 20.0);
+        let order = Order::market_buy("ABC", 20.0, "exchange");
         orderbook.insert_order(order, 100);
 
         let completed_trades = orderbook.execute_orders(&quotes, &trades, 100);
@@ -1152,22 +1180,24 @@ mod tests {
             size: 20.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level.clone(), Side::Bid);
         depth.add_level(ask_level.clone(), Side::Ask);
 
-        let mut depth_101 = Depth::new(101, "ABC");
+        let mut depth_101 = Depth::new(101, "ABC", "exchange");
         depth_101.add_level(bid_level.clone(), Side::Bid);
         depth_101.add_level(ask_level.clone(), Side::Ask);
 
-        let mut depth_102 = Depth::new(102, "ABC");
+        let mut depth_102 = Depth::new(102, "ABC", "exchange");
         depth_102.add_level(bid_level, Side::Bid);
         depth_102.add_level(ask_level, Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
-        quotes.insert("ABC".to_string(), depth_101);
-        quotes.insert("ABC".to_string(), depth_102);
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        let exchange = quotes.get_mut("exchange").unwrap();
+        exchange.insert("ABC".to_string(), depth);
+        exchange.insert("ABC".to_string(), depth_101);
+        exchange.insert("ABC".to_string(), depth_102);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -1175,6 +1205,7 @@ mod tests {
             px: 98.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -1182,15 +1213,16 @@ mod tests {
             px: 102.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
         trades.insert(100, vec![bid_trade, ask_trade]);
 
         let mut orderbook = OrderBook::new();
-        let order = Order::limit_buy("ABC", 20.0, 103.00);
-        let order1 = Order::limit_buy("ABC", 20.0, 103.00);
-        let order2 = Order::limit_buy("ABC", 20.0, 103.00);
+        let order = Order::limit_buy("ABC", 20.0, 103.00, "exchange");
+        let order1 = Order::limit_buy("ABC", 20.0, 103.00, "exchange");
+        let order2 = Order::limit_buy("ABC", 20.0, 103.00, "exchange");
 
         let res = orderbook.insert_order(order, 100);
         let res1 = orderbook.insert_order(order1, 100);
@@ -1216,12 +1248,13 @@ mod tests {
             size: 100.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level.clone(), Side::Bid);
         depth.add_level(ask_level.clone(), Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -1229,6 +1262,7 @@ mod tests {
             px: 98.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -1236,15 +1270,16 @@ mod tests {
             px: 102.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
         trades.insert(100, vec![bid_trade, ask_trade]);
 
         let mut orderbook = OrderBook::new();
-        let buy_order = Order::limit_buy("ABC", 10.0, 98.00);
+        let buy_order = Order::limit_buy("ABC", 10.0, 98.00, "exchange");
         orderbook.insert_order(buy_order, 99);
-        let sell_order = Order::limit_sell("ABC", 10.0, 102.00);
+        let sell_order = Order::limit_sell("ABC", 10.0, 102.00, "exchange");
         orderbook.insert_order(sell_order, 99);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);
@@ -1263,12 +1298,13 @@ mod tests {
             size: 100.0,
         };
 
-        let mut depth = Depth::new(100, "ABC");
+        let mut depth = Depth::new(100, "ABC", "exchange");
         depth.add_level(bid_level.clone(), Side::Bid);
         depth.add_level(ask_level.clone(), Side::Ask);
 
         let mut quotes: DateDepth = BTreeMap::new();
-        quotes.insert("ABC".to_string(), depth);
+        quotes.insert("exchange".to_string(), BTreeMap::new());
+        quotes.get_mut("exchange").unwrap().insert("ABC".to_string(), depth);
 
         let bid_trade = Trade {
             coin: "ABC".to_string(),
@@ -1276,6 +1312,7 @@ mod tests {
             px: 98.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
         let ask_trade = Trade {
             coin: "ABC".to_string(),
@@ -1283,15 +1320,16 @@ mod tests {
             px: 102.0,
             sz: 20.0,
             time: 100,
+            exchange: "exchange".to_string(),
         };
 
         let mut trades: DateTrade = BTreeMap::new();
         trades.insert(100, vec![bid_trade, ask_trade]);
 
         let mut orderbook = OrderBook::new();
-        let buy_order = Order::limit_buy("ABC", 40.0, 98.00);
+        let buy_order = Order::limit_buy("ABC", 40.0, 98.00, "exchange");
         orderbook.insert_order(buy_order, 99);
-        let sell_order = Order::limit_sell("ABC", 40.0, 102.00);
+        let sell_order = Order::limit_sell("ABC", 40.0, 102.00, "exchange");
         orderbook.insert_order(sell_order, 99);
 
         let res = orderbook.execute_orders(&quotes, &trades, 100);

--- a/rotala/src/input/athena.rs
+++ b/rotala/src/input/athena.rs
@@ -24,7 +24,12 @@ impl Athena {
         self.inner.range(dates)
     }
 
-    pub fn get_best_bid(&self, dates: std::ops::Range<i64>, symbol: &str, exchange: &str) -> Option<&Level> {
+    pub fn get_best_bid(
+        &self,
+        dates: std::ops::Range<i64>,
+        symbol: &str,
+        exchange: &str,
+    ) -> Option<&Level> {
         let depth_between = self.get_quotes_between(dates);
         if let Some(last_depth) = depth_between.last() {
             if let Some(exchange_depth) = last_depth.1.get(exchange) {
@@ -36,7 +41,12 @@ impl Athena {
         None
     }
 
-    pub fn get_best_ask(&self, dates: std::ops::Range<i64>, symbol: &str, exchange: &str) -> Option<&Level> {
+    pub fn get_best_ask(
+        &self,
+        dates: std::ops::Range<i64>,
+        symbol: &str,
+        exchange: &str,
+    ) -> Option<&Level> {
         let depth_between = self.get_quotes_between(dates);
         if let Some(last_depth) = depth_between.last() {
             if let Some(exchange_depth) = last_depth.1.get(exchange) {
@@ -74,7 +84,14 @@ impl Athena {
         date_map.get_mut(&exchange).unwrap().insert(symbol, depth);
     }
 
-    pub fn add_price_level(&mut self, date: i64, symbol: &str, level: Level, side: Side, exchange: &str) {
+    pub fn add_price_level(
+        &mut self,
+        date: i64,
+        symbol: &str,
+        level: Level,
+        side: Side,
+        exchange: &str,
+    ) {
         self.inner.entry(date).or_default();
 
         let date_map = self.inner.get_mut(&date).unwrap();
@@ -194,8 +211,23 @@ mod tests {
         athena.add_price_level(100, "ABC", bid1, Side::Bid, "exchange");
         athena.add_price_level(100, "ABC", ask1, Side::Ask, "exchange");
 
-        println!("{:?}", athena.get_best_bid(100..101, "ABC", "exchange").unwrap());
-        assert_eq!(athena.get_best_bid(100..101, "ABC" ,"exchange").unwrap().price, 101.0);
-        assert_eq!(athena.get_best_ask(100..101, "ABC", "exchange").unwrap().price, 102.0);
+        println!(
+            "{:?}",
+            athena.get_best_bid(100..101, "ABC", "exchange").unwrap()
+        );
+        assert_eq!(
+            athena
+                .get_best_bid(100..101, "ABC", "exchange")
+                .unwrap()
+                .price,
+            101.0
+        );
+        assert_eq!(
+            athena
+                .get_best_ask(100..101, "ABC", "exchange")
+                .unwrap()
+                .price,
+            102.0
+        );
     }
 }

--- a/rotala/src/input/athena.rs
+++ b/rotala/src/input/athena.rs
@@ -24,33 +24,39 @@ impl Athena {
         self.inner.range(dates)
     }
 
-    pub fn get_best_bid(&self, dates: std::ops::Range<i64>, symbol: &str) -> Option<&Level> {
+    pub fn get_best_bid(&self, dates: std::ops::Range<i64>, exchange: &str, symbol: &str) -> Option<&Level> {
         let depth_between = self.get_quotes_between(dates);
         if let Some(last_depth) = depth_between.last() {
-            if let Some(coin_depth) = last_depth.1.get(symbol) {
-                return coin_depth.get_best_bid();
+            if let Some(exchange_depth) = last_depth.1.get(exchange) {
+                if let Some(coin_depth) = exchange_depth.get(symbol) {
+                    return coin_depth.get_best_bid();
+                }
             }
         }
         None
     }
 
-    pub fn get_best_ask(&self, dates: std::ops::Range<i64>, symbol: &str) -> Option<&Level> {
+    pub fn get_best_ask(&self, dates: std::ops::Range<i64>, symbol: &str, exchange: &str) -> Option<&Level> {
         let depth_between = self.get_quotes_between(dates);
         if let Some(last_depth) = depth_between.last() {
-            if let Some(coin_depth) = last_depth.1.get(symbol) {
-                return coin_depth.get_best_ask();
+            if let Some(exchange_depth) = last_depth.1.get(exchange) {
+                if let Some(coin_depth) = exchange_depth.get(symbol) {
+                    return coin_depth.get_best_ask();
+                }
             }
         }
         None
     }
 
-    pub fn get_bbo(&self, dates: std::ops::Range<i64>) -> Option<DateBBO> {
+    pub fn get_bbo(&self, dates: std::ops::Range<i64>, exchange: &str) -> Option<DateBBO> {
         let mut res = BTreeMap::new();
 
         let depth_between = self.get_quotes_between(dates);
         if let Some(last_depth) = depth_between.last() {
-            for (symbol, depth) in last_depth.1 {
-                res.insert(symbol.clone(), depth.get_bbo()?);
+            if let Some(exchange_depth) = last_depth.1.get(exchange) {
+                for (symbol, depth) in exchange_depth {
+                    res.insert(symbol.clone(), depth.get_bbo()?);
+                }
             }
         }
         Some(res)
@@ -59,21 +65,23 @@ impl Athena {
     pub fn add_depth(&mut self, depth: Depth) {
         let date = depth.date;
         let symbol = depth.symbol.clone();
+        let exchange = depth.exchange.clone();
 
         self.inner.entry(date).or_default();
 
-        let date_levels = self.inner.get_mut(&date).unwrap();
-        date_levels.insert(symbol, depth);
+        let date_map = self.inner.get_mut(&date).unwrap();
+        date_map.entry(exchange.to_string()).or_default();
+        date_map.get_mut(&exchange).unwrap().insert(symbol, depth);
     }
 
-    pub fn add_price_level(&mut self, date: i64, symbol: &str, level: Level, side: Side) {
+    pub fn add_price_level(&mut self, date: i64, symbol: &str, level: Level, side: Side, exchange: &str) {
         self.inner.entry(date).or_default();
 
-        let symbol_string = symbol.into();
+        let date_map = self.inner.get_mut(&date).unwrap();
+        date_map.entry(exchange.to_string()).or_default();
 
-        //We will always have a value due to the above block so can unwrap safely
-        let date_levels = self.inner.get_mut(&date).unwrap();
-        if let Some(depth) = date_levels.get_mut(&symbol_string) {
+        let date_levels = date_map.get_mut(&exchange.to_string()).unwrap();
+        if let Some(depth) = date_levels.get_mut(symbol) {
             depth.add_level(level, side)
         } else {
             let depth = match side {
@@ -82,16 +90,18 @@ impl Athena {
                     asks: vec![],
                     symbol: symbol.to_string(),
                     date,
+                    exchange: exchange.to_string(),
                 },
                 Side::Ask => Depth {
                     bids: vec![],
                     asks: vec![level],
                     symbol: symbol.to_string(),
                     date,
+                    exchange: exchange.to_string(),
                 },
             };
 
-            date_levels.insert(symbol_string, depth);
+            date_levels.insert(symbol.to_string(), depth);
         }
     }
 
@@ -117,8 +127,8 @@ impl Athena {
                     size: random_size,
                 };
 
-                source.add_price_level(date, symbol, bid_level, Side::Bid);
-                source.add_price_level(date, symbol, ask_level, Side::Ask);
+                source.add_price_level(date, symbol, bid_level, Side::Bid, "exchange");
+                source.add_price_level(date, symbol, ask_level, Side::Ask, "exchange");
             }
         }
         source
@@ -178,13 +188,13 @@ mod tests {
             size: 100.0,
         };
 
-        athena.add_price_level(100, "ABC", bid0, Side::Bid);
-        athena.add_price_level(100, "ABC", ask0, Side::Ask);
+        athena.add_price_level(100, "ABC", bid0, Side::Bid, "exchange");
+        athena.add_price_level(100, "ABC", ask0, Side::Ask, "exchange");
 
-        athena.add_price_level(100, "ABC", bid1, Side::Bid);
-        athena.add_price_level(100, "ABC", ask1, Side::Ask);
+        athena.add_price_level(100, "ABC", bid1, Side::Bid, "exchange");
+        athena.add_price_level(100, "ABC", ask1, Side::Ask, "exchange");
 
-        assert_eq!(athena.get_best_bid(100..101, "ABC").unwrap().price, 101.0);
-        assert_eq!(athena.get_best_ask(100..101, "ABC").unwrap().price, 102.0);
+        assert_eq!(athena.get_best_bid(100..101, "ABC" ,"exchange").unwrap().price, 101.0);
+        assert_eq!(athena.get_best_ask(100..101, "ABC", "exchange").unwrap().price, 102.0);
     }
 }

--- a/rotala/src/input/athena.rs
+++ b/rotala/src/input/athena.rs
@@ -24,7 +24,7 @@ impl Athena {
         self.inner.range(dates)
     }
 
-    pub fn get_best_bid(&self, dates: std::ops::Range<i64>, exchange: &str, symbol: &str) -> Option<&Level> {
+    pub fn get_best_bid(&self, dates: std::ops::Range<i64>, symbol: &str, exchange: &str) -> Option<&Level> {
         let depth_between = self.get_quotes_between(dates);
         if let Some(last_depth) = depth_between.last() {
             if let Some(exchange_depth) = last_depth.1.get(exchange) {
@@ -194,6 +194,7 @@ mod tests {
         athena.add_price_level(100, "ABC", bid1, Side::Bid, "exchange");
         athena.add_price_level(100, "ABC", ask1, Side::Ask, "exchange");
 
+        println!("{:?}", athena.get_best_bid(100..101, "ABC", "exchange").unwrap());
         assert_eq!(athena.get_best_bid(100..101, "ABC" ,"exchange").unwrap().price, 101.0);
         assert_eq!(athena.get_best_ask(100..101, "ABC", "exchange").unwrap().price, 102.0);
     }

--- a/rotala/src/input/minerva.rs
+++ b/rotala/src/input/minerva.rs
@@ -108,33 +108,43 @@ impl Minerva {
                 )
                 .await;
 
-            let mut sort_into_dates: HashMap<i64, HashMap<String, Vec<L2Book>>> = HashMap::new();
+            let mut sort_into_dates: HashMap<i64, HashMap<String, HashMap<String, Vec<L2Book>>>> = HashMap::new();
             if let Ok(rows) = query_result {
                 for row in rows {
                     if let Ok(book) = L2Book::from_row(row) {
                         sort_into_dates.entry(book.time).or_default();
 
                         let date = sort_into_dates.get_mut(&book.time).unwrap();
+                        let quote_name = format!("{}@{}", book.coin, book.exchange);
 
-                        if !date.contains_key(&book.coin) {
-                            date.insert(book.coin.clone(), Vec::new());
+                        if !date.contains_key(&book.exchange) {
+                            date.insert(book.exchange.clone(), HashMap::new());
                         }
 
-                        let coin_date: &mut Vec<L2Book> = date.get_mut(&book.coin).unwrap();
+                        let exchange = date.get_mut(&book.exchange).unwrap();
+
+                        if !exchange.contains_key(&book.coin) {
+                            exchange.insert(book.coin.clone(), Vec::new());
+                        }
+
+                        let coin_date: &mut Vec<L2Book> = exchange.get_mut(&quote_name).unwrap();
                         coin_date.push(book);
                     }
                 }
             }
 
-            for (date, coin_map) in sort_into_dates.iter_mut() {
-                for (coin, book) in coin_map.iter_mut() {
-                    let depth: Depth = std::mem::take(book).into();
+            for (date, exchange_map) in sort_into_dates.iter_mut() {
+                for (exchange, coin_map) in exchange_map.iter_mut() {
+                    for (coin, book) in coin_map.iter_mut() {
+                        let depth: Depth = std::mem::take(book).into();
 
-                    self.depths.entry(*date).or_default();
-                    self.depths
-                        .get_mut(date)
-                        .unwrap()
-                        .insert(coin.to_string(), depth);
+                        self.depths.entry(*date).or_default();
+                        let date_map = self.depths.get_mut(date).unwrap();
+
+                        date_map.entry(exchange.to_string()).or_default();
+
+                        date_map.get_mut(exchange).unwrap().insert(coin.to_string(), depth);
+                    }
                 }
             }
         }

--- a/rotala/src/input/minerva.rs
+++ b/rotala/src/input/minerva.rs
@@ -41,6 +41,7 @@ impl From<Trade> for crate::source::hyperliquid::Trade {
             px: str::parse::<f64>(&value.px).unwrap(),
             sz: str::parse::<f64>(&value.sz).unwrap(),
             time: value.time,
+            exchange: value.exchange,
         }
     }
 }
@@ -52,6 +53,7 @@ impl From<Vec<L2Book>> for Depth {
 
         let date = values.first().unwrap().time;
         let symbol = values.first().unwrap().coin.clone();
+        let exchange = values.first().unwrap().exchange.clone();
 
         for row in values {
             match row.side {
@@ -71,6 +73,7 @@ impl From<Vec<L2Book>> for Depth {
             asks,
             date,
             symbol,
+            exchange,
         }
     }
 }
@@ -137,12 +140,10 @@ impl Minerva {
                 for (exchange, coin_map) in exchange_map.iter_mut() {
                     for (coin, book) in coin_map.iter_mut() {
                         let depth: Depth = std::mem::take(book).into();
-
                         self.depths.entry(*date).or_default();
+
                         let date_map = self.depths.get_mut(date).unwrap();
-
                         date_map.entry(exchange.to_string()).or_default();
-
                         date_map.get_mut(exchange).unwrap().insert(coin.to_string(), depth);
                     }
                 }

--- a/rotala/src/input/minerva.rs
+++ b/rotala/src/input/minerva.rs
@@ -111,7 +111,8 @@ impl Minerva {
                 )
                 .await;
 
-            let mut sort_into_dates: HashMap<i64, HashMap<String, HashMap<String, Vec<L2Book>>>> = HashMap::new();
+            let mut sort_into_dates: HashMap<i64, HashMap<String, HashMap<String, Vec<L2Book>>>> =
+                HashMap::new();
             if let Ok(rows) = query_result {
                 for row in rows {
                     if let Ok(book) = L2Book::from_row(row) {
@@ -144,7 +145,10 @@ impl Minerva {
 
                         let date_map = self.depths.get_mut(date).unwrap();
                         date_map.entry(exchange.to_string()).or_default();
-                        date_map.get_mut(exchange).unwrap().insert(coin.to_string(), depth);
+                        date_map
+                            .get_mut(exchange)
+                            .unwrap()
+                            .insert(coin.to_string(), depth);
                     }
                 }
             }

--- a/rotala/src/input/minerva.rs
+++ b/rotala/src/input/minerva.rs
@@ -119,7 +119,6 @@ impl Minerva {
                         sort_into_dates.entry(book.time).or_default();
 
                         let date = sort_into_dates.get_mut(&book.time).unwrap();
-                        let quote_name = format!("{}@{}", book.coin, book.exchange);
 
                         if !date.contains_key(&book.exchange) {
                             date.insert(book.exchange.clone(), HashMap::new());
@@ -131,7 +130,7 @@ impl Minerva {
                             exchange.insert(book.coin.clone(), Vec::new());
                         }
 
-                        let coin_date: &mut Vec<L2Book> = exchange.get_mut(&quote_name).unwrap();
+                        let coin_date: &mut Vec<L2Book> = exchange.get_mut(&book.coin).unwrap();
                         coin_date.push(book);
                     }
                 }

--- a/rotala/src/source/hyperliquid.rs
+++ b/rotala/src/source/hyperliquid.rs
@@ -182,6 +182,6 @@ pub struct Trade {
     pub time: i64,
 }
 
-pub type DateDepth = BTreeMap<String, Depth>;
+pub type DateDepth = BTreeMap<String, BTreeMap<String, Depth>>;
 pub type DateBBO = BTreeMap<String, BBO>;
 pub type DateTrade = BTreeMap<i64, Vec<Trade>>;

--- a/rotala/src/source/hyperliquid.rs
+++ b/rotala/src/source/hyperliquid.rs
@@ -45,6 +45,7 @@ impl From<L2Book> for Depth {
     fn from(value: L2Book) -> Depth {
         let date = value.raw.data.time as i64;
         let symbol = value.raw.data.coin;
+        let exchange = "hl".to_string();
 
         let mut bids_depth: Vec<Level> = Vec::new();
         let mut asks_depth: Vec<Level> = Vec::new();
@@ -66,6 +67,7 @@ impl From<L2Book> for Depth {
             asks: asks_depth,
             date,
             symbol,
+            exchange,
         }
     }
 }
@@ -113,6 +115,7 @@ pub struct Depth {
     pub asks: Vec<Level>,
     pub date: i64,
     pub symbol: String,
+    pub exchange: String,
 }
 
 impl Depth {
@@ -153,12 +156,13 @@ impl Depth {
         })
     }
 
-    pub fn new(date: i64, symbol: impl Into<String>) -> Self {
+    pub fn new(date: i64, symbol: impl Into<String>, exchange: impl Into<String>) -> Self {
         Self {
             bids: vec![],
             asks: vec![],
             date,
             symbol: symbol.into(),
+            exchange: exchange.into(),
         }
     }
 }
@@ -180,6 +184,7 @@ pub struct Trade {
     pub px: f64,
     pub sz: f64,
     pub time: i64,
+    pub exchange: String,
 }
 
 pub type DateDepth = BTreeMap<String, BTreeMap<String, Depth>>;


### PR DESCRIPTION
Previously Minerva was indexed by coin/symbol, added a new level for exchanges. Orders now expect exchange field, and OrderResult returns exchange field.

Python client not updated but testing working with actual backtesting application.